### PR TITLE
FIX : datepicker date format for other locale used

### DIFF
--- a/js/timelineScheduler.js
+++ b/js/timelineScheduler.js
@@ -1059,6 +1059,7 @@ var TimeScheduler = {
             })
             .appendTo($(this))
             .datepicker({
+				dateFormat: "yy-mm-dd",
                 onClose: function () {
                     $(this).remove();
                 },

--- a/js/timelineScheduler.js
+++ b/js/timelineScheduler.js
@@ -26,6 +26,12 @@
 /// <reference path="jquery-ui-1.10.2.custom.min.js" />
 /// <reference path="moment.min.js" />
 
+;(function (global, factory) {
+    typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+    typeof define === 'function' && define.amd ? define(factory) :
+    global.TimeScheduler = factory()
+}(this, (function () { 'use strict';
+var isEven,time;
 var TimeScheduler = {
     Options: {
         /* The function to call to fill up Sections.
@@ -1106,3 +1112,7 @@ var TimeScheduler = {
         TimeScheduler.SelectPeriod($(this).data('period').Name);
     }
 };
+
+return TimeScheduler;
+
+})));

--- a/js/timelineScheduler.js
+++ b/js/timelineScheduler.js
@@ -249,7 +249,11 @@ var TimeScheduler = {
 
         TimeScheduler.Options.Start = moment(TimeScheduler.Options.Start);
 
-        TimeScheduler.Options.Element.find('.ui-draggable').draggable('destroy');
+		// it only destroys draggable element if dragging is enabled
+		if(TimeScheduler.Options.AllowDragging){
+	        TimeScheduler.Options.Element.find('.ui-draggable').draggable('destroy');
+		}
+
         TimeScheduler.Options.Element.empty();
 
         TimeScheduler.Wrapper = $(document.createElement('div'))


### PR DESCRIPTION
This pull request add the compatibility with requireJS 

---- FIXES ----
1 - Date format 
Before the fix, if the user locale is, for example, the french locale, the date format returned is dd/mm/yy instead of yy-mm-dd. If the user click on the 13th of December, the date won't be recognised by moment. 
Now, the datepicker always returns a yy-mm-dd formatted date value. 

2 - Dragging not allowed
Even is allowDragging option was set to false, it called the draggable jquery-ui fonction to destroy some element during the initialization. 
I surrounded this call so that it is done only if the allowDragging option is enabled
Moreover, if jquery-ui is not included because not needed, it will also work. 
